### PR TITLE
feat(mobile): add log and check end time in us

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -140,15 +140,24 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
                 }
 
                 val dataSource = if (startTime != null || duration != null){
+                    val mediaInfo = Utility(channelName).getMediaInfoJson(context, path)
+                    val videoDurationMs = mediaInfo.optLong("duration", 0)
+                    val videoDurationUs = videoDurationMs * 1000L
+
                     val source = UriDataSource(context, Uri.parse(path))
                     val startTimeInUs = (1000 * (startTime ?: 0)).toLong()
                     val durationInUs = (1000 * (duration ?: 0)).toLong()
-                    val endTimeInUs = startTimeInUs + durationInUs
+                    var endTimeInUs = startTimeInUs + durationInUs
+                    
+                    Log.d(TAG, "startTimeInUs: $startTimeInUs, endTimeInUs: $endTimeInUs, durationInUs: $durationInUs, videoDurationUs: $videoDurationUs")
+                    if (endTimeInUs > videoDurationUs) {
+                        endTimeInUs = videoDurationUs
+                    }
+
                     ClipDataSource(source, startTimeInUs, endTimeInUs)
                 }else{
                     UriDataSource(context, Uri.parse(path))
                 }
-
 
                 transcodeFuture = Transcoder.into(destPath!!)
                         .addDataSource(dataSource)


### PR DESCRIPTION
不對影片做 trim end 的操作時， 在 android compress video 所取得的 video duration 會比 flutter 傳入的參數計算後還小，因此會有 Exception 出現，所以增加 endTimeInUs 的檢查，ios 看起來已經有處理所以就沒修改([link](https://github.com/XRSPACE-Inc/VideoCompress/blob/master/ios/Classes/SwiftVideoCompressPlugin.swift#L195))
```
I/flutter (17475): Error from VideoCompress: 
I/flutter (17475):       Method: compressVideo
I/flutter (17475):       PlatformException(error, Trim values cannot be negative., null, java.lang.IllegalArgumentException: Trim values cannot be negative.
```
`D/VideoCompressPlugin(29997): startTimeInUs: 0, endTimeInUs: 17555000, durationInUs: 17555000, videoDurationUs: 17554000`